### PR TITLE
fix: densify the S&R module page (was ~4 viewports tall)

### DIFF
--- a/components/dashboardv2/modules/ModulePageShell.tsx
+++ b/components/dashboardv2/modules/ModulePageShell.tsx
@@ -21,21 +21,21 @@ export default function ModulePageShell({
   children,
 }: ModulePageShellProps) {
   return (
-    <div className="min-h-screen bg-[#020203] px-6 pb-10 pt-36 text-white sm:px-8 lg:px-10">
+    <div className="min-h-screen bg-[#020203] px-4 pb-6 pt-20 text-white sm:px-6 lg:px-8">
       <div className={["mx-auto", maxWidth].join(" ")}>
-        <div className="relative overflow-hidden rounded-[38px] border border-white/8 bg-[linear-gradient(180deg,rgba(10,10,14,0.88),rgba(4,4,7,0.96))] shadow-[0_30px_90px_rgba(0,0,0,0.42)] backdrop-blur-2xl">
+        <div className="relative overflow-hidden rounded-[22px] border border-white/8 bg-[linear-gradient(180deg,rgba(10,10,14,0.88),rgba(4,4,7,0.96))] shadow-[0_20px_60px_rgba(0,0,0,0.4)] backdrop-blur-2xl">
           <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.05),transparent_36%),radial-gradient(circle_at_88%_18%,rgba(139,92,246,0.07),transparent_18%)]" />
           <div className="pointer-events-none absolute inset-0 opacity-[0.08] [background-image:radial-gradient(rgba(255,255,255,0.06)_1px,transparent_1px)] [background-size:11px_11px]" />
 
-          <div className="relative z-10 p-6 sm:p-8 lg:p-10">
-            <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
+          <div className="relative z-10 px-4 py-3.5 sm:px-5">
+            <div className="flex flex-col gap-2 xl:flex-row xl:items-center xl:justify-between">
               <div className="max-w-3xl">
-                <div className="inline-flex items-center rounded-full border border-white/12 bg-white/[0.03] px-4 py-2 text-[11px] font-medium uppercase tracking-[0.28em] text-white/72">
+                <div className="inline-flex items-center rounded-full border border-white/12 bg-white/[0.03] px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.24em] text-white/64">
                   {eyebrow}
                 </div>
-                <h1 className="mt-4 text-3xl font-semibold tracking-tight text-white sm:text-4xl">{title}</h1>
+                <h1 className="mt-1.5 text-xl font-semibold tracking-tight text-white sm:text-2xl">{title}</h1>
                 {description ? (
-                  <p className="mt-3 max-w-3xl text-sm leading-relaxed text-white/48 sm:text-base">{description}</p>
+                  <p className="mt-1 max-w-3xl text-xs leading-relaxed text-white/44 sm:text-sm">{description}</p>
                 ) : null}
               </div>
 
@@ -44,7 +44,7 @@ export default function ModulePageShell({
           </div>
         </div>
 
-        <motion.div initial={{ opacity: 0, y: 18 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.28 }} className="mt-6">
+        <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.24 }} className="mt-3">
           {children}
         </motion.div>
       </div>

--- a/components/support-resistance/SupportResistanceAlphaModule.tsx
+++ b/components/support-resistance/SupportResistanceAlphaModule.tsx
@@ -20,13 +20,13 @@ interface SupportResistanceAlphaModuleProps {
 
 function StatCard({ label, value, note, icon: Icon }: { label: string; value: string; note?: string; icon: React.ComponentType<{ className?: string }> }) {
   return (
-    <div className="rounded-[18px] border border-white/10 bg-white/[0.03] px-3.5 py-3">
-      <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.2em] text-white/34">
-        <Icon className="h-3.5 w-3.5" />
+    <div className="rounded-xl border border-white/10 bg-white/[0.03] px-2.5 py-1.5">
+      <div className="flex items-center gap-1.5 text-[9px] uppercase tracking-[0.16em] text-white/34">
+        <Icon className="h-3 w-3" />
         {label}
       </div>
-      <div className="mt-1.5 text-sm font-semibold text-white">{value}</div>
-      {note ? <div className="mt-1 text-sm text-white/44">{note}</div> : null}
+      <div className="mt-0.5 text-[13px] font-semibold leading-tight text-white">{value}</div>
+      {note ? <div className="text-[11px] leading-tight text-white/40">{note}</div> : null}
     </div>
   );
 }
@@ -127,112 +127,89 @@ export function SupportResistanceAlphaModule({
   }
 
   return (
-    <div className="grid gap-4">
-      <header className="rounded-[24px] border border-white/10 bg-[linear-gradient(135deg,rgba(14,20,27,0.94),rgba(8,10,15,0.96))] px-4 py-4 shadow-[0_18px_42px_rgba(0,0,0,0.24)] sm:px-5">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2">
-              <h2 className="text-xl font-semibold tracking-[-0.02em] text-white sm:text-2xl">EURUSD Support Reclaim Alpha</h2>
-              <span className="rounded-full border border-sky-300/18 bg-sky-300/[0.08] px-3 py-1 text-[10px] uppercase tracking-[0.18em] text-sky-100">
-                Alpha: EURUSD support only
-              </span>
-            </div>
-            <p className="mt-1.5 max-w-3xl text-sm leading-relaxed text-white/58">
-              Research-backed support-zone opportunity grading for short-term first reactions.
-            </p>
-            <p className="mt-1 text-xs text-white/38">Resistance zones, more pairs, and live Supabase scoring are coming later.</p>
-          </div>
-          <div className="grid gap-2 sm:grid-cols-3 lg:min-w-[520px]">
-            <StatCard
-              icon={Shield}
-              label="Stop context"
-              value={`${supportResistanceAlphaScope.stopBufferAtr.toFixed(2)} ATR`}
-              note="Buffer reference"
-            />
-            <StatCard
-              icon={Target}
-              label="Target context"
-              value={`~${supportResistanceAlphaScope.firstReactionTargetR.toFixed(2)}R`}
-              note="First reaction"
-            />
-            <StatCard icon={Clock3} label="Session filter" value={supportResistanceAlphaScope.sessionFilter} note="M15 context" />
-          </div>
+    <div className="grid gap-3">
+      <header className="flex flex-col gap-2 rounded-2xl border border-white/10 bg-[linear-gradient(135deg,rgba(14,20,27,0.94),rgba(8,10,15,0.96))] px-3.5 py-2.5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded-full border border-sky-300/18 bg-sky-300/[0.08] px-2.5 py-0.5 text-[10px] uppercase tracking-[0.16em] text-sky-100">
+            Alpha: EURUSD support only
+          </span>
+          <span className="text-xs text-white/48">Support-zone opportunity grading · short-term first reactions</span>
+        </div>
+        <div className="grid grid-cols-3 gap-2 sm:min-w-[360px]">
+          <StatCard icon={Shield} label="Stop" value={`${supportResistanceAlphaScope.stopBufferAtr.toFixed(2)} ATR`} note="Buffer" />
+          <StatCard icon={Target} label="Target" value={`~${supportResistanceAlphaScope.firstReactionTargetR.toFixed(2)}R`} note="First reaction" />
+          <StatCard icon={Clock3} label="Session" value={supportResistanceAlphaScope.sessionFilter} note="M15" />
         </div>
       </header>
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.7fr)]">
+      <div className="grid gap-3 xl:grid-cols-[minmax(0,1.6fr)_minmax(300px,1fr)]">
         <SupportResistanceLightweightChart
           candles={candles}
           zones={chartZones}
           selectedZoneId={selectedZoneId}
           onSelectZone={setSelectedZoneId}
         />
-        <ZoneDetailsPanel zone={selectedZone} />
+        <div className="max-h-[520px] overflow-y-auto">
+          <ZoneDetailsPanel zone={selectedZone} />
+        </div>
       </div>
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]">
+      <div className="grid gap-3 xl:grid-cols-[minmax(0,1.5fr)_minmax(280px,1fr)]">
         <SupportResistanceScanner rows={visibleScannerRows} selectedZoneId={selectedZoneId} onSelectZone={setSelectedZoneId} />
 
-        <aside className="grid gap-4">
-          <section className="rounded-[24px] border border-white/10 bg-[linear-gradient(180deg,rgba(17,17,23,0.92),rgba(10,10,15,0.95))] p-4">
-            <div className="text-[11px] uppercase tracking-[0.22em] text-white/34">Alpha scope</div>
-            <h3 className="mt-2 text-lg font-semibold text-white">{supportResistanceAlphaScope.alphaName}</h3>
-            <p className="mt-2 text-sm leading-relaxed text-white/46">
-              Alpha v1 is limited to EURUSD M15 support-reclaim research context. It does not cover resistance zones, other assets, or execution guidance.
-            </p>
-            <div className="mt-3 grid gap-2">
+        <aside className="grid gap-3">
+          <section className="rounded-[18px] border border-white/10 bg-[linear-gradient(180deg,rgba(17,17,23,0.92),rgba(10,10,15,0.95))] p-3">
+            <div className="text-[10px] uppercase tracking-[0.18em] text-white/34">Alpha scope</div>
+            <div className="mt-2 grid gap-1.5">
               {supportResistanceCopy.scopeNotes.map((note) => (
-                <div key={note} className="rounded-[16px] border border-white/8 bg-white/[0.03] px-3 py-2.5 text-sm text-white/58">
+                <div key={note} className="rounded-[12px] border border-white/8 bg-white/[0.03] px-2.5 py-1.5 text-xs text-white/56">
                   {note}
                 </div>
               ))}
             </div>
           </section>
 
-          <section className="rounded-[24px] border border-white/10 bg-[linear-gradient(180deg,rgba(17,17,23,0.92),rgba(10,10,15,0.95))] p-4">
-            <div className="text-[11px] uppercase tracking-[0.22em] text-white/34">Interpretation help</div>
-            <div className="mt-3 grid gap-2">
-              <div className="flex items-center justify-between gap-3 rounded-[16px] border border-white/8 bg-white/[0.03] px-3 py-2.5 text-sm text-white/64">
-                <span>Static strength vs dynamic grade</span>
-                <EducationalTooltip label={supportResistanceCopy.tooltips.staticVsDynamic} align="right" />
-              </div>
-              <div className="flex items-center justify-between gap-3 rounded-[16px] border border-white/8 bg-white/[0.03] px-3 py-2.5 text-sm text-white/64">
-                <span>Blue zones</span>
-                <EducationalTooltip label={supportResistanceCopy.tooltips.blueZones} align="right" />
-              </div>
-              <div className="flex items-center justify-between gap-3 rounded-[16px] border border-white/8 bg-white/[0.03] px-3 py-2.5 text-sm text-white/64">
-                <span>Watch and Blocked states</span>
-                <EducationalTooltip label={supportResistanceCopy.tooltips.watchBlocked} align="right" />
-              </div>
-              <div className="flex items-center justify-between gap-3 rounded-[16px] border border-white/8 bg-white/[0.03] px-3 py-2.5 text-sm text-white/64">
-                <span>A+ meaning</span>
-                <EducationalTooltip label={supportResistanceCopy.tooltips.aPlusMeaning} align="right" />
-              </div>
-              <div className="flex items-center justify-between gap-3 rounded-[16px] border border-white/8 bg-white/[0.03] px-3 py-2.5 text-sm text-white/64">
-                <span>Research-only framing</span>
-                <EducationalTooltip label={supportResistanceCopy.tooltips.notSignal} align="right" />
-              </div>
+          <section className="rounded-[18px] border border-white/10 bg-[linear-gradient(180deg,rgba(17,17,23,0.92),rgba(10,10,15,0.95))] p-3">
+            <div className="text-[10px] uppercase tracking-[0.18em] text-white/34">Interpretation help</div>
+            <div className="mt-2 grid gap-1.5">
+              {(
+                [
+                  ["Static strength vs dynamic grade", supportResistanceCopy.tooltips.staticVsDynamic],
+                  ["Blue zones", supportResistanceCopy.tooltips.blueZones],
+                  ["Watch and Blocked states", supportResistanceCopy.tooltips.watchBlocked],
+                  ["A+ meaning", supportResistanceCopy.tooltips.aPlusMeaning],
+                  ["Research-only framing", supportResistanceCopy.tooltips.notSignal],
+                ] as const
+              ).map(([label, tip]) => (
+                <div
+                  key={label}
+                  className="flex items-center justify-between gap-2 rounded-[12px] border border-white/8 bg-white/[0.03] px-2.5 py-1.5 text-xs text-white/64"
+                >
+                  <span>{label}</span>
+                  <EducationalTooltip label={tip} align="right" />
+                </div>
+              ))}
             </div>
           </section>
 
-          <section className="rounded-[24px] border border-amber-300/16 bg-amber-300/[0.06] p-4">
-            <div className="text-[11px] uppercase tracking-[0.22em] text-amber-100">Decision-support framing</div>
-            <p className="mt-2 text-sm leading-relaxed text-amber-50/82">{supportResistanceCopy.disclaimer}</p>
+          <section className="rounded-[18px] border border-amber-300/16 bg-amber-300/[0.06] p-3">
+            <div className="text-[10px] uppercase tracking-[0.18em] text-amber-100">Decision-support framing</div>
+            <p className="mt-1.5 text-xs leading-relaxed text-amber-50/82">{supportResistanceCopy.disclaimer}</p>
           </section>
         </aside>
       </div>
 
-      <section className="rounded-[24px] border border-white/10 bg-[linear-gradient(180deg,rgba(14,14,20,0.88),rgba(8,9,13,0.92))] p-4">
+      <section className="rounded-[18px] border border-white/10 bg-[linear-gradient(180deg,rgba(14,14,20,0.88),rgba(8,9,13,0.92))] p-3">
         <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <div className="text-[11px] uppercase tracking-[0.22em] text-white/34">Research profile</div>
-            <h3 className="mt-1 text-lg font-semibold text-white">Historical validation sample</h3>
+            <div className="text-[10px] uppercase tracking-[0.18em] text-white/34">Research profile</div>
+            <h3 className="mt-0.5 text-sm font-semibold text-white">Historical validation sample</h3>
           </div>
-          <p className="max-w-xl text-sm leading-relaxed text-white/46">
-            Supporting context only. The primary workflow stays chart, details, scanner, then research profile.
+          <p className="max-w-xl text-xs leading-relaxed text-white/44">
+            Supporting context only. Primary workflow stays chart, details, scanner, then research profile.
           </p>
         </div>
-        <div className="mt-3 grid gap-3 lg:grid-cols-3">
+        <div className="mt-2 grid gap-2 lg:grid-cols-3">
           {profiles.map((profile) => (
             <ResearchProfileCard key={profile.id} profile={profile} />
           ))}

--- a/components/support-resistance/ZoneDetailsPanel.tsx
+++ b/components/support-resistance/ZoneDetailsPanel.tsx
@@ -13,9 +13,9 @@ interface ZoneDetailsPanelProps {
 
 function DetailItem({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-4 py-3">
-      <div className="text-[10px] uppercase tracking-[0.18em] text-white/34">{label}</div>
-      <div className="mt-2 text-sm font-medium text-white">{value}</div>
+    <div className="rounded-xl border border-white/8 bg-white/[0.03] px-2.5 py-1.5">
+      <div className="text-[9px] uppercase tracking-[0.16em] text-white/34">{label}</div>
+      <div className="mt-0.5 text-[13px] font-medium text-white">{value}</div>
     </div>
   );
 }
@@ -42,47 +42,47 @@ export function ZoneDetailsPanel({ zone }: ZoneDetailsPanelProps) {
   const details = buildZoneDetails(zone);
 
   return (
-    <aside className="rounded-[24px] border border-white/10 bg-[linear-gradient(180deg,rgba(17,17,23,0.92),rgba(10,10,15,0.96))] p-4 shadow-[0_20px_50px_rgba(0,0,0,0.28)]">
-      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-white/8 pb-3">
+    <aside className="rounded-[20px] border border-white/10 bg-[linear-gradient(180deg,rgba(17,17,23,0.92),rgba(10,10,15,0.96))] p-3 shadow-[0_20px_50px_rgba(0,0,0,0.28)]">
+      <div className="flex flex-wrap items-start justify-between gap-2 border-b border-white/8 pb-2.5">
         <div>
-          <div className="text-[11px] uppercase tracking-[0.22em] text-white/34">Zone details</div>
-          <h3 className="mt-2 text-lg font-semibold text-white">{details.zoneLabel}</h3>
-          <p className="mt-1 text-sm text-white/46">{details.educationalSummary}</p>
+          <div className="text-[10px] uppercase tracking-[0.18em] text-white/34">Zone details</div>
+          <h3 className="mt-1 text-base font-semibold text-white">{details.zoneLabel}</h3>
+          <p className="mt-0.5 text-xs text-white/46">{details.educationalSummary}</p>
         </div>
         <OpportunityGradeBadge grade={details.dynamicGrade} />
       </div>
 
-      <div className="mt-3 grid gap-2.5">
+      <div className="mt-2 grid gap-2">
         <DetailItem label="Pair" value={details.pair} />
         <DetailItem label="Timeframe" value={details.timeframe} />
         <DetailItem label="Zone side" value="Support" />
 
-        <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-4 py-3">
-          <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-white/34">
+        <div className="rounded-xl border border-white/8 bg-white/[0.03] px-2.5 py-2">
+          <div className="flex items-center gap-2 text-[9px] uppercase tracking-[0.16em] text-white/34">
             Static strength
             <EducationalTooltip label={supportResistanceCopy.tooltips.staticVsDynamic} align="right" />
           </div>
-          <div className="mt-3">
+          <div className="mt-2">
             <StaticStrengthMeter strength={details.staticStrength} />
           </div>
-          <div className="mt-2 text-sm text-white/52">{details.staticStrengthNote}</div>
+          <div className="mt-1.5 text-xs text-white/52">{details.staticStrengthNote}</div>
         </div>
 
-        <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-4 py-3">
-          <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-white/34">
+        <div className="rounded-xl border border-white/8 bg-white/[0.03] px-2.5 py-2">
+          <div className="flex items-center gap-2 text-[9px] uppercase tracking-[0.16em] text-white/34">
             Dynamic opportunity grade
             <EducationalTooltip label={supportResistanceCopy.tooltips.aPlusMeaning} align="right" />
           </div>
-          <div className="mt-3">
+          <div className="mt-2">
             <OpportunityGradeBadge grade={details.dynamicGrade} />
           </div>
-          <div className="mt-2 text-sm text-white/52">{details.dynamicGradeNote}</div>
-          <div className="mt-3 rounded-[12px] border border-white/8 bg-black/20 px-3 py-2 text-xs leading-relaxed text-white/48">
+          <div className="mt-1.5 text-xs text-white/52">{details.dynamicGradeNote}</div>
+          <div className="mt-2 rounded-[10px] border border-white/8 bg-black/20 px-2.5 py-1.5 text-[11px] leading-relaxed text-white/48">
             Dynamic grade can upgrade or downgrade as price approaches the zone.
           </div>
         </div>
 
-        <div className="pt-1 text-[10px] uppercase tracking-[0.2em] text-white/34">Context quality</div>
+        <div className="pt-0.5 text-[9px] uppercase tracking-[0.18em] text-white/34">Context quality</div>
         <DetailItem label="Research reaction range" value={formatReactionRange(details.reactionRange)} />
         <DetailItem
           label="Typical minimum reaction"
@@ -102,27 +102,27 @@ export function ZoneDetailsPanel({ zone }: ZoneDetailsPanelProps) {
         <DetailItem label="Last updated" value={`${formatTimestamp(details.lastUpdated)} UTC`} />
       </div>
 
-      <div className="mt-4 rounded-[20px] border border-amber-300/16 bg-amber-300/[0.06] px-4 py-4">
-        <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-amber-100">
-          <Clock3 className="h-3.5 w-3.5" />
+      <div className="mt-2 rounded-[14px] border border-amber-300/16 bg-amber-300/[0.06] px-3 py-2.5">
+        <div className="flex items-center gap-2 text-[9px] uppercase tracking-[0.16em] text-amber-100">
+          <Clock3 className="h-3 w-3" />
           Educational disclaimer
         </div>
-        <p className="mt-2 text-sm leading-relaxed text-amber-50/80">{supportResistanceCopy.disclaimer}</p>
+        <p className="mt-1 text-xs leading-relaxed text-amber-50/80">{supportResistanceCopy.disclaimer}</p>
       </div>
 
       {details.dynamicGrade === "a_plus" ? (
-        <div className="mt-4 rounded-[20px] border border-[#F7E38C]/18 bg-[#F7E38C]/[0.06] px-4 py-4 text-sm leading-relaxed text-[#FFF1B1]">
+        <div className="mt-2 rounded-[14px] border border-[#F7E38C]/18 bg-[#F7E38C]/[0.06] px-3 py-2.5 text-xs leading-relaxed text-[#FFF1B1]">
           A+ = highest-quality short-term first-reaction setup, not a reversal call.
         </div>
       ) : null}
 
       {details.notes ? (
-        <div className="mt-4 rounded-[20px] border border-white/8 bg-white/[0.03] px-4 py-4">
-          <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-white/34">
-            <Waves className="h-3.5 w-3.5" />
+        <div className="mt-2 rounded-[14px] border border-white/8 bg-white/[0.03] px-3 py-2.5">
+          <div className="flex items-center gap-2 text-[9px] uppercase tracking-[0.16em] text-white/34">
+            <Waves className="h-3 w-3" />
             Research note
           </div>
-          <p className="mt-2 text-sm leading-relaxed text-white/60">{details.notes}</p>
+          <p className="mt-1 text-xs leading-relaxed text-white/60">{details.notes}</p>
         </div>
       ) : null}
     </aside>

--- a/components/support-resistance/chartSizing.ts
+++ b/components/support-resistance/chartSizing.ts
@@ -4,7 +4,7 @@ export interface ChartLogicalRange {
 }
 
 export function getSupportResistanceChartMinHeight(compact: boolean): number {
-  return compact ? 270 : 620;
+  return compact ? 270 : 460;
 }
 
 export function getSupportResistanceChartViewportHeight(host: HTMLElement | null, fallbackHeight: number): number {


### PR DESCRIPTION
/support-resistance sprawled to ~4 viewports. Tighten spacing/typography and restructure so it uses space optimally:

- ModulePageShell: smaller top padding, header font, radii and gaps (applies to all module pages — denser header everywhere).
- SupportResistanceAlphaModule: drop the duplicate in-module title (shell already shows it); slim header to a badge + compact stat strip; hero row is now chart | details with the details panel capped at 520px and scrolling internally (kills the ~1200px row + the empty gap); gap-4→gap-3; compact aside (scope/interpretation/disclaimer) and research profiles; denser StatCard.
- ZoneDetailsPanel: tighter DetailItem, header, blocks, disclaimer/notes.
- Chart floor 620→460 (no longer stretches to the tall details panel).

Owner-verified in dev. Type-checked green (local prod build only fails on the known dev-server/.next turbopack contamination).