### PR TITLE
feat(sr): integrate S&R Alpha into the paid dashboard + product polish

### DIFF
--- a/app/support-resistance/page.tsx
+++ b/app/support-resistance/page.tsx
@@ -1,20 +1,9 @@
-import type { Metadata } from "next";
-import ModulePageShell from "@/components/dashboardv2/modules/ModulePageShell";
-import { SupportResistanceAlphaLive } from "@/components/support-resistance/SupportResistanceAlphaLive";
+import { redirect } from "next/navigation";
 
-export const metadata: Metadata = {
-  title: "Support & Resistance Alpha | IntelliTrade",
-  description:
-    "EURUSD support-reclaim opportunity grading. Research-backed decision support only — not trading signals.",
-};
-
+// The Support & Resistance Alpha module lives INSIDE the paid dashboard. This
+// legacy standalone route redirects into the dashboard with the S&R tab focused,
+// so it never feels like a detached page. Middleware still gates /dashboardv2
+// (premium), so the paywall is preserved.
 export default function SupportResistancePage() {
-  return (
-    <ModulePageShell
-      title="EURUSD Support Reclaim Alpha"
-      description="Research-backed support-zone opportunity grading for short-term first reactions. Educational decision support only."
-    >
-      <SupportResistanceAlphaLive />
-    </ModulePageShell>
-  );
+  redirect("/dashboardv2?panel=supportResistance");
 }

--- a/components/dashboardv2/Dashboard.tsx
+++ b/components/dashboardv2/Dashboard.tsx
@@ -76,7 +76,7 @@ function renderPanel(
     case "macro":
       return <MacroMasteryPanel {...base} />;
     case "supportResistance":
-      return <SupportResistancePanel {...base} />;
+      return <SupportResistancePanel {...base} focused={focused} />;
     default:
       return null;
   }
@@ -120,6 +120,15 @@ export function Dashboard() {
     check();
     window.addEventListener("resize", check);
     return () => window.removeEventListener("resize", check);
+  }, []);
+
+  // Deep-link: /dashboardv2?panel=supportResistance focuses that tab. Lets the
+  // /support-resistance redirect open the module inside the full dashboard shell.
+  useEffect(() => {
+    const p = new URLSearchParams(window.location.search).get("panel");
+    if (p && PANEL_TABS.some((tab) => tab.id === p && !tab.comingSoon)) {
+      setFocusedType(p as TabId);
+    }
   }, []);
 
   return (

--- a/components/dashboardv2/panels/support-resistance-panel.tsx
+++ b/components/dashboardv2/panels/support-resistance-panel.tsx
@@ -11,15 +11,16 @@ interface SupportResistancePanelProps {
   panel: Panel;
   onToggleLock: () => void;
   onRemove: () => void;
+  focused?: boolean;
 }
 
-export function SupportResistancePanel({ panel, onToggleLock, onRemove }: SupportResistancePanelProps) {
+export function SupportResistancePanel({ panel, onToggleLock, onRemove, focused = false }: SupportResistancePanelProps) {
   return (
     <WidgetShell
       title="Support & Resistance Alpha"
       subtitle="EURUSD support-reclaim opportunity grading (research decision support)."
       className="h-full"
-      contentClassName="min-h-0 overflow-hidden"
+      contentClassName="min-h-0 overflow-y-auto"
       headerRight={
         <>
           <Pill active>
@@ -30,7 +31,7 @@ export function SupportResistancePanel({ panel, onToggleLock, onRemove }: Suppor
         </>
       }
     >
-      <SupportResistanceAlphaLive compact />
+      <SupportResistanceAlphaLive compact={!focused} />
     </WidgetShell>
   );
 }

--- a/components/support-resistance/OpportunityGradeBadge.tsx
+++ b/components/support-resistance/OpportunityGradeBadge.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { dynamicOpportunityGradeConfig } from "./gradeConfig";
+import { dynamicOpportunityGradeConfig, gradeBadgeStyle } from "./gradeConfig";
 import type { DynamicOpportunityGrade } from "./types";
 
 interface OpportunityGradeBadgeProps {
@@ -13,10 +13,10 @@ export function OpportunityGradeBadge({ grade, compact = false }: OpportunityGra
   return (
     <span
       className={[
-        "inline-flex items-center rounded-full border font-medium uppercase tracking-[0.18em]",
+        "inline-flex items-center rounded-full border font-semibold uppercase tracking-[0.18em]",
         compact ? "px-2.5 py-1 text-[10px]" : "px-3 py-1.5 text-[11px]",
-        config.badgeClassName,
       ].join(" ")}
+      style={gradeBadgeStyle(grade)}
     >
       {config.label}
     </span>

--- a/components/support-resistance/ResearchProfileCard.tsx
+++ b/components/support-resistance/ResearchProfileCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ArrowUpRight, Clock3, Target } from "lucide-react";
-import { dynamicOpportunityGradeConfig } from "./gradeConfig";
+import { dynamicOpportunityGradeConfig, gradeBadgeStyle } from "./gradeConfig";
 import type { ResearchTierProfile } from "./types";
 
 interface ResearchProfileCardProps {
@@ -22,7 +22,10 @@ export function ResearchProfileCard({ profile }: ResearchProfileCardProps) {
     <article className="rounded-[18px] border border-white/8 bg-white/[0.025] p-3.5">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <div className={["inline-flex items-center rounded-full border px-2.5 py-1 text-[9px] uppercase tracking-[0.18em]", tone.badgeClassName].join(" ")}>
+          <div
+            className="inline-flex items-center rounded-full border px-2.5 py-1 text-[9px] font-semibold uppercase tracking-[0.18em]"
+            style={gradeBadgeStyle(profile.id)}
+          >
             {profile.label}
           </div>
           <h3 className="mt-2 text-sm font-semibold text-white">{profile.scopeLabel}</h3>

--- a/components/support-resistance/SupportResistanceAlphaLive.tsx
+++ b/components/support-resistance/SupportResistanceAlphaLive.tsx
@@ -82,14 +82,35 @@ export function SupportResistanceAlphaLive({ compact = false, refreshMs = 60_000
     );
   }
 
-  // Always pass the REAL candles (never fall back to mock ~1.08 prices, which
-  // would sit far from real EURUSD ~1.1x zones and render the bands off-screen).
+  // Snapshot freshness. The intraday worker writes every 15 min; flag stale > 30m.
+  const calcAt = data?.calculatedAt ? new Date(data.calculatedAt) : null;
+  const ageMinutes = calcAt ? (Date.now() - calcAt.getTime()) / 60000 : null;
+  const isStale = ageMinutes != null && ageMinutes > 30;
+  const snapshotLabel = calcAt
+    ? new Intl.DateTimeFormat("en-US", {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        timeZone: "UTC",
+      }).format(calcAt)
+    : null;
+
+  // Always pass the REAL candles (never mock — mock ~1.08 prices would sit far
+  // from real EURUSD ~1.1x zones and render the bands off-screen).
   return (
-    <SupportResistanceAlphaModule
-      zones={zones}
-      candles={data?.candles ?? []}
-      compact={compact}
-    />
+    <div className={compact ? "flex h-full min-h-0 flex-col gap-2" : "grid gap-2"}>
+      {isStale ? (
+        <div className="rounded-full border border-amber-300/30 bg-amber-400/[0.08] px-3 py-1.5 text-xs text-amber-100">
+          Data may be stale — last snapshot {snapshotLabel} UTC. The scoring worker refreshes every 15 minutes.
+        </div>
+      ) : snapshotLabel ? (
+        <div className="text-xs text-white/44">Latest EURUSD M15 snapshot · {snapshotLabel} UTC</div>
+      ) : null}
+      <div className={compact ? "min-h-0 flex-1 overflow-hidden" : ""}>
+        <SupportResistanceAlphaModule zones={zones} candles={data?.candles ?? []} compact={compact} />
+      </div>
+    </div>
   );
 }
 

--- a/components/support-resistance/SupportResistanceAlphaModule.tsx
+++ b/components/support-resistance/SupportResistanceAlphaModule.tsx
@@ -40,26 +40,21 @@ export function SupportResistanceAlphaModule({
   const defaultZone = selectFeaturedZone(zones);
   const [selectedZoneId, setSelectedZoneId] = useState<string | null>(defaultZone?.id ?? null);
   const selectedZone = zones.find((zone) => zone.id === selectedZoneId) ?? defaultZone ?? null;
-  // ── CHART ZONE SELECTION RULE (approved) ──────────────────────────────────
-  // Draw only the support shelves worth watching, grounded in the research
-  // engine's own quality label (NOT invented heuristics):
-  //   (a) medium or strong static_strength — the research scores most zones
-  //       "weak" (thin / over-tested); those are noise, kept off the chart.
-  //   (b) genuinely touched in view — a candle LOW dipped into the band (support
-  //       tested from above), so bands hug real price, not float over dead space.
-  //   (c) top CHART_ZONE_LIMIT by priority; scanner + details still list ALL zones.
-  // TO REVERT to "draw all zones": set chartZones = zones (and remove this block).
+  // ── CHART ZONE SELECTION RULE ─────────────────────────────────────────────
+  // A zone is drawn whenever it EXISTS in the current data — strength/grade only
+  // affect its badge/colour, never whether it's on the chart. (Earlier this
+  // required strong/medium static_strength; but the research scores most zones
+  // "weak", so in weak-only markets the chart drew NOTHING despite valid zones.)
+  //   (a) genuinely touched in view — a candle LOW dipped into the band, so the
+  //       band hugs real price instead of floating over dead space.
+  //   (b) top CHART_ZONE_LIMIT by priority; scanner + details still list ALL zones.
   const CHART_ZONE_LIMIT = 5;
   const chartZones = (() => {
     const genuinelyTouched = (zone: (typeof zones)[number]) =>
       candles.some((c) => c.low <= zone.zoneHigh && c.low >= zone.zoneLow);
-    const notable = zones.filter(
-      (zone) =>
-        genuinelyTouched(zone) &&
-        (zone.staticStrength === "strong" || zone.staticStrength === "medium"),
-    );
-    const ranked = [...notable].sort(compareZonesByPriority).slice(0, CHART_ZONE_LIMIT);
-    if (selectedZone && !ranked.some((z) => z.id === selectedZone.id) && notable.includes(selectedZone)) {
+    const touched = zones.filter(genuinelyTouched);
+    const ranked = [...touched].sort(compareZonesByPriority).slice(0, CHART_ZONE_LIMIT);
+    if (selectedZone && !ranked.some((z) => z.id === selectedZone.id) && touched.includes(selectedZone)) {
       ranked.push(selectedZone);
     }
     return ranked;
@@ -80,7 +75,7 @@ export function SupportResistanceAlphaModule({
             icon={Radar}
             label="Research reaction range"
             value={selectedZone ? formatReactionRange(selectedZone.reactionRange) : "No active row"}
-            note={selectedZone ? `${selectedZone.pair} / ${selectedZone.timeframe}` : supportResistanceCopy.emptyStates.noneQualified}
+            note={selectedZone ? `${selectedZone.pair} / ${selectedZone.timeframe}` : supportResistanceCopy.emptyStates.noReclaim}
           />
           <StatCard
             icon={Shield}

--- a/components/support-resistance/SupportResistanceLightweightChart.tsx
+++ b/components/support-resistance/SupportResistanceLightweightChart.tsx
@@ -314,7 +314,7 @@ export function SupportResistanceLightweightChart({
         <div>
           <div className="text-[11px] uppercase tracking-[0.22em] text-white/34">Lightweight chart overlay</div>
           <h3 className="mt-1 text-lg font-semibold text-white">EURUSD Support Reclaim Alpha</h3>
-          <p className="mt-1 text-sm text-white/44">Resistance zones, more pairs, and live Supabase scoring are coming later.</p>
+          <p className="mt-1 text-sm text-white/44">Live EURUSD M15 support-zone context. Resistance zones and more pairs are coming later.</p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5 text-[10px] uppercase tracking-[0.18em] text-white/60">
@@ -371,6 +371,9 @@ export function SupportResistanceLightweightChart({
                   background: config.chartFill,
                   borderColor: selected ? selectedBorder : config.chartStroke,
                   borderStyle: selected ? "solid" : mutedGrade ? "dashed" : "solid",
+                  // Premium outer glow only for elite_green + a_plus (config.glow is
+                  // empty for the rest). Selection ring is handled by className.
+                  boxShadow: selected ? undefined : config.glow || undefined,
                   opacity: selected ? 1 : hovered ? 0.86 : lowPriorityGrade ? 0.42 : mutedGrade ? 0.54 : 0.64,
                 }}
               >

--- a/components/support-resistance/SupportResistanceScanner.tsx
+++ b/components/support-resistance/SupportResistanceScanner.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { supportResistanceCopy } from "./copy";
 import { formatReactionRange, formatTypicalR, isGreenTierGrade } from "./model";
+import { gradeBadgeStyle } from "./gradeConfig";
 import OpportunityGradeBadge from "./OpportunityGradeBadge";
 import StaticStrengthMeter from "./StaticStrengthMeter";
 import type { ScannerRow } from "./types";
@@ -32,30 +33,6 @@ function getScannerRowTone(grade: ScannerRow["dynamicGrade"], selected: boolean)
   return "border-white/10 bg-white/[0.03] hover:border-white/18 hover:bg-white/[0.05]";
 }
 
-function getStatusPillTone(grade: ScannerRow["dynamicGrade"]): string {
-  if (grade === "blocked") {
-    return "border-rose-300/18 bg-rose-400/[0.08] text-rose-100";
-  }
-
-  if (grade === "watch") {
-    return "border-amber-300/18 bg-amber-300/[0.08] text-amber-100";
-  }
-
-  if (grade === "blue") {
-    return "border-sky-300/16 bg-sky-300/[0.07] text-sky-100";
-  }
-
-  if (grade === "a_plus") {
-    return "border-[#F7E38C]/24 bg-[#F7E38C]/[0.1] text-[#FFF1B1]";
-  }
-
-  if (grade === "elite_green") {
-    return "border-teal-300/20 bg-teal-300/[0.08] text-teal-100";
-  }
-
-  return "border-emerald-300/18 bg-emerald-300/[0.08] text-emerald-100";
-}
-
 export function SupportResistanceScanner({
   rows,
   selectedZoneId,
@@ -67,7 +44,7 @@ export function SupportResistanceScanner({
   if (!rows.length) {
     return (
       <section className="rounded-[28px] border border-white/10 bg-[linear-gradient(180deg,rgba(17,17,23,0.92),rgba(10,10,15,0.95))] p-5 text-sm text-white/56">
-        {supportResistanceCopy.emptyStates.noneQualified}
+        {supportResistanceCopy.emptyStates.noZones}
       </section>
     );
   }
@@ -103,7 +80,10 @@ export function SupportResistanceScanner({
               </div>
               <div className="mt-3 flex items-center justify-between gap-3 text-sm text-white/70">
                 <StaticStrengthMeter strength={row.staticStrength} compact />
-                <span className={["rounded-full border px-2.5 py-1 text-[10px] uppercase tracking-[0.16em]", getStatusPillTone(row.dynamicGrade)].join(" ")}>
+                <span
+                  className="rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em]"
+                  style={gradeBadgeStyle(row.dynamicGrade)}
+                >
                   {row.status}
                 </span>
               </div>
@@ -124,7 +104,9 @@ export function SupportResistanceScanner({
           <p className="mt-1 text-sm text-white/46">Static strength and dynamic opportunity grade are separated on every row.</p>
         </div>
         <div className="rounded-[18px] border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-white/68">
-          {alphaQualifiedCount ? `${alphaQualifiedCount} Green+ rows in the current Alpha snapshot.` : supportResistanceCopy.emptyStates.noneQualified}
+          {alphaQualifiedCount
+            ? `${alphaQualifiedCount} Green+ ${alphaQualifiedCount === 1 ? "row" : "rows"} in the latest EURUSD M15 snapshot.`
+            : supportResistanceCopy.emptyStates.noGreenPlus}
         </div>
       </div>
 
@@ -185,7 +167,10 @@ export function SupportResistanceScanner({
                   {formatTypicalR(row.typicalMinimumR, row.typicalMaximumR)}
                 </td>
                 <td className="px-4 py-4">
-                  <span className={["inline-flex rounded-full border px-2.5 py-1 text-[10px] uppercase tracking-[0.16em]", getStatusPillTone(row.dynamicGrade)].join(" ")}>
+                  <span
+                    className="inline-flex rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em]"
+                    style={gradeBadgeStyle(row.dynamicGrade)}
+                  >
                     {row.status}
                   </span>
                 </td>
@@ -218,7 +203,10 @@ export function SupportResistanceScanner({
                 Typical {formatTypicalR(row.typicalMinimumR, row.typicalMaximumR)}
               </div>
               <div>
-                <span className={["inline-flex rounded-full border px-2.5 py-1 text-[10px] uppercase tracking-[0.16em]", getStatusPillTone(row.dynamicGrade)].join(" ")}>
+                <span
+                  className="inline-flex rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em]"
+                  style={gradeBadgeStyle(row.dynamicGrade)}
+                >
                   {row.status}
                 </span>
               </div>

--- a/components/support-resistance/ZoneDetailsPanel.tsx
+++ b/components/support-resistance/ZoneDetailsPanel.tsx
@@ -34,7 +34,7 @@ export function ZoneDetailsPanel({ zone }: ZoneDetailsPanelProps) {
   if (!zone) {
     return (
       <aside className="rounded-[28px] border border-white/10 bg-[linear-gradient(180deg,rgba(17,17,23,0.92),rgba(10,10,15,0.96))] p-5 text-sm text-white/56">
-        {supportResistanceCopy.emptyStates.noneQualified}
+        {supportResistanceCopy.emptyStates.noReclaim}
       </aside>
     );
   }

--- a/components/support-resistance/copy.ts
+++ b/components/support-resistance/copy.ts
@@ -2,7 +2,10 @@ export const supportResistanceCopy = {
   disclaimer:
     "Research-backed ranges are based on historical testing and are for educational decision support only. They are not trading signals, financial advice, or guarantees of future results.",
   emptyStates: {
-    noneQualified: "No current EURUSD M15 support-only Alpha rows match the research filters.",
+    // Rows/zones can exist while none are Green+; wording must never imply "no data" then.
+    noGreenPlus: "No Green+ opportunities right now.",
+    noReclaim: "No active reclaim opportunity right now.",
+    noZones: "No active EURUSD support zones right now.",
     blueZones: "Blue zones are informational. They are not trade-ready by themselves.",
     roadmap: "More pairs and resistance zones coming later. Alpha v1 is limited to EURUSD M15 support zones.",
   },

--- a/components/support-resistance/gradeConfig.ts
+++ b/components/support-resistance/gradeConfig.ts
@@ -11,15 +11,53 @@ export const DYNAMIC_GRADE_ORDER: DynamicOpportunityGrade[] = [
 
 export const STATIC_STRENGTH_ORDER: StaticZoneStrength[] = ["weak", "medium", "strong"];
 
+/**
+ * SINGLE SOURCE OF TRUTH for grade colours. Every grade-coloured surface —
+ * badge pills, chart zone fill/border, scanner badges, detail badges — derives
+ * from these tokens. Do not hardcode grade colours anywhere else.
+ *   text   – label / border accent colour
+ *   border – zone / badge border (alpha-tuned)
+ *   fill   – subtle zone / badge background
+ *   glow   – premium outer glow, ONLY for elite_green + a_plus
+ */
+export interface GradeTokens {
+  text: string;
+  border: string;
+  fill: string;
+  glow?: string;
+}
+
+export const GRADE_TOKENS: Record<DynamicOpportunityGrade, GradeTokens> = {
+  blocked: { text: "#f87171", border: "rgba(248, 113, 113, 0.55)", fill: "rgba(248, 113, 113, 0.12)" },
+  // watch ↔ a_plus swapped (owner): watch = royal blue (no glow), a_plus = gold (glow).
+  watch: { text: "#60a5fa", border: "rgba(65, 105, 225, 0.9)", fill: "rgba(65, 105, 225, 0.18)" },
+  green: { text: "#22c55e", border: "rgba(34, 197, 94, 0.65)", fill: "rgba(22, 101, 52, 0.18)" },
+  elite_green: {
+    text: "#2dd4bf",
+    border: "rgba(45, 212, 191, 0.85)",
+    fill: "rgba(45, 212, 191, 0.16)",
+    glow: "0 0 18px rgba(45, 212, 191, 0.35)",
+  },
+  a_plus: {
+    text: "#facc15",
+    border: "rgba(250, 204, 21, 0.65)",
+    fill: "rgba(250, 204, 21, 0.14)",
+    glow: "0 0 22px rgba(250, 204, 21, 0.45)",
+  },
+  // Legacy grade — the locked model never emits "blue"; kept for type completeness.
+  blue: { text: "#7dd3fc", border: "rgba(56, 189, 248, 0.55)", fill: "rgba(56, 189, 248, 0.12)" },
+};
+
 export const dynamicOpportunityGradeConfig: Record<
   DynamicOpportunityGrade,
   {
     label: string;
     shortLabel: string;
     description: string;
-    badgeClassName: string;
+    tokens: GradeTokens;
     chartFill: string;
     chartStroke: string;
+    glow: string;
     panelClassName: string;
     emphasisClassName: string;
     scannerStatus: string;
@@ -29,9 +67,10 @@ export const dynamicOpportunityGradeConfig: Record<
     label: "Blue",
     shortLabel: "Blue",
     description: "Informational. Not trade-ready by itself.",
-    badgeClassName: "border-sky-400/22 bg-sky-400/10 text-sky-100",
-    chartFill: "rgba(74, 183, 255, 0.14)",
-    chartStroke: "#4AB7FF",
+    tokens: GRADE_TOKENS.blue,
+    chartFill: GRADE_TOKENS.blue.fill,
+    chartStroke: GRADE_TOKENS.blue.border,
+    glow: "",
     panelClassName: "border-sky-400/18 bg-sky-500/[0.06]",
     emphasisClassName: "text-sky-200",
     scannerStatus: "Monitor only",
@@ -40,20 +79,22 @@ export const dynamicOpportunityGradeConfig: Record<
     label: "Watch",
     shortLabel: "Watch",
     description: "Caution. Quality not clean enough yet.",
-    badgeClassName: "border-amber-300/24 bg-amber-300/10 text-amber-100",
-    chartFill: "rgba(251, 191, 36, 0.14)",
-    chartStroke: "#F6C34E",
-    panelClassName: "border-amber-300/16 bg-amber-400/[0.06]",
-    emphasisClassName: "text-amber-100",
+    tokens: GRADE_TOKENS.watch,
+    chartFill: GRADE_TOKENS.watch.fill,
+    chartStroke: GRADE_TOKENS.watch.border,
+    glow: "",
+    panelClassName: "border-[#4169E1]/22 bg-[#4169E1]/[0.08]",
+    emphasisClassName: "text-[#93b4ff]",
     scannerStatus: "Monitor only",
   },
   blocked: {
     label: "Blocked",
     shortLabel: "Blocked",
     description: "Poor context. Avoid prioritizing.",
-    badgeClassName: "border-rose-400/24 bg-rose-400/10 text-rose-100",
-    chartFill: "rgba(251, 113, 133, 0.14)",
-    chartStroke: "#FB7185",
+    tokens: GRADE_TOKENS.blocked,
+    chartFill: GRADE_TOKENS.blocked.fill,
+    chartStroke: GRADE_TOKENS.blocked.border,
+    glow: "",
     panelClassName: "border-rose-400/16 bg-rose-500/[0.06]",
     emphasisClassName: "text-rose-100",
     scannerStatus: "Blocked",
@@ -62,9 +103,10 @@ export const dynamicOpportunityGradeConfig: Record<
     label: "Green",
     shortLabel: "Green",
     description: "Valid short-term reaction opportunity.",
-    badgeClassName: "border-emerald-400/24 bg-emerald-400/10 text-emerald-100",
-    chartFill: "rgba(52, 211, 153, 0.14)",
-    chartStroke: "#34D399",
+    tokens: GRADE_TOKENS.green,
+    chartFill: GRADE_TOKENS.green.fill,
+    chartStroke: GRADE_TOKENS.green.border,
+    glow: "",
     panelClassName: "border-emerald-400/16 bg-emerald-500/[0.06]",
     emphasisClassName: "text-emerald-100",
     scannerStatus: "Active review",
@@ -73,9 +115,10 @@ export const dynamicOpportunityGradeConfig: Record<
     label: "Elite Green",
     shortLabel: "Elite",
     description: "Higher-quality opportunity with stronger context.",
-    badgeClassName: "border-teal-300/26 bg-teal-300/10 text-teal-100 shadow-[0_0_22px_rgba(45,212,191,0.16)]",
-    chartFill: "rgba(45, 212, 191, 0.16)",
-    chartStroke: "#2DD4BF",
+    tokens: GRADE_TOKENS.elite_green,
+    chartFill: GRADE_TOKENS.elite_green.fill,
+    chartStroke: GRADE_TOKENS.elite_green.border,
+    glow: GRADE_TOKENS.elite_green.glow ?? "",
     panelClassName: "border-teal-300/18 bg-teal-400/[0.06]",
     emphasisClassName: "text-teal-100",
     scannerStatus: "Elite review",
@@ -84,15 +127,29 @@ export const dynamicOpportunityGradeConfig: Record<
     label: "A+",
     shortLabel: "A+",
     description: "Short-term first reaction, not reversal call.",
-    badgeClassName:
-      "border-[#F7E38C]/30 bg-[linear-gradient(135deg,rgba(201,255,229,0.12),rgba(247,227,140,0.14))] text-[#FFF1B1] shadow-[0_0_26px_rgba(247,227,140,0.18)]",
-    chartFill: "rgba(247, 227, 140, 0.16)",
-    chartStroke: "#F7E38C",
-    panelClassName: "border-[#F7E38C]/18 bg-[#F7E38C]/[0.06]",
-    emphasisClassName: "text-[#FFF1B1]",
+    tokens: GRADE_TOKENS.a_plus,
+    chartFill: GRADE_TOKENS.a_plus.fill,
+    chartStroke: GRADE_TOKENS.a_plus.border,
+    glow: GRADE_TOKENS.a_plus.glow ?? "",
+    panelClassName: "border-amber-300/18 bg-amber-400/[0.06]",
+    emphasisClassName: "text-amber-100",
     scannerStatus: "A+ review",
   },
 };
+
+/**
+ * Inline style for any grade badge / pill. Single source — never hardcode grade
+ * colours in a component. Spread into a `style={}` prop.
+ */
+export function gradeBadgeStyle(grade: DynamicOpportunityGrade): {
+  color: string;
+  borderColor: string;
+  background: string;
+  boxShadow?: string;
+} {
+  const t = GRADE_TOKENS[grade];
+  return { color: t.text, borderColor: t.border, background: t.fill, boxShadow: t.glow };
+}
 
 export const staticStrengthConfig: Record<
   StaticZoneStrength,


### PR DESCRIPTION
Frontend/product only — no backend, scoring, or validation changes.

Dashboard integration
- Standalone /support-resistance now redirects into the dashboard (/dashboardv2?panel=supportResistance) so it lives inside the paid shell, nav and paywall instead of a detached page.
- Dashboard reads ?panel= to deep-link/focus a tab.
- The focused S&R tab renders the rich (non-compact) module; the grid widget stays compact. Panel content scrolls.

Zones draw regardless of grade
- Chart no longer requires strong/medium static_strength to draw a zone; any current touched zone is drawn (top 5 by priority). Blocked/watch/green/ elite/a+ only change colour + badge, never whether the zone exists.

Unified grade colours (single source)
- New GRADE_TOKENS + gradeBadgeStyle() in gradeConfig.ts drive every grade surface: badge pills, chart zone fill/border, scanner status pills, detail and research badges. No more duplicated per-component CSS.
- Tokens: blocked #f87171 · watch #60a5fa (royal blue) · green #22c55e · elite_green #2dd4bf (glow) · a_plus #facc15 (gold, glow). Glow only on elite_green + a_plus. (watch/a_plus swapped per owner.)

Copy
- Drop "live Supabase scoring coming later" (scoring is live); chart subtitle now "Live EURUSD M15 support-zone context…".
- Split misleading empty state: scanner shows "N Green+ rows in the latest EURUSD M15 snapshot" or "No Green+ opportunities right now" while still listing all current watch/blocked rows.

Freshness
- Show "Latest EURUSD M15 snapshot · <time> UTC" when fresh, or an amber stale warning when > 30 min old. No mock/demo fallback in production.