### PR TITLE
fix: count actual forward candles so market closures do not block eva…

### DIFF
--- a/intellitrade_scanners/review/evaluator.py
+++ b/intellitrade_scanners/review/evaluator.py
@@ -52,14 +52,17 @@ def forward_open_times(reference_close_time: dt.datetime, count: int) -> list[dt
 
 def contiguous_forward(candle_map: dict, reference_close_time: dt.datetime,
                        want: int = LONG_BARS) -> tuple[list[dict], int]:
-    """Return (forward_candles, verified_bars) walking the weekday grid from
-    forward bar 1, stopping at the first missing bar."""
-    forward: list[dict] = []
-    for open_time in forward_open_times(reference_close_time, want):
-        candle = candle_map.get(open_time)
-        if candle is None:
-            break
-        forward.append(candle)
+    """Return (forward_candles, verified_bars): the next `want` ACTUAL closed
+    candles at/after forward bar 1's open, in time order.
+
+    Bar counting per the horizon convention (§3.5/§4.7): forward bar N is the Nth
+    real closed candle after the reference. Weekends AND market closures (holidays
+    like Dec 25 / Jan 1) have no candle and simply vanish through bar counting -
+    they are not gaps and must not block. `want` bars available => complete;
+    fewer means the window has not fully closed yet. Genuine multi-day feed
+    outages surface via the candles-stage gap detection + watchdog, not here."""
+    forward_times = sorted(t for t in candle_map if t >= reference_close_time)
+    forward = [candle_map[t] for t in forward_times[:want]]
     return forward, len(forward)
 
 

--- a/intellitrade_scanners/tests/review/test_evaluator.py
+++ b/intellitrade_scanners/tests/review/test_evaluator.py
@@ -105,11 +105,17 @@ def test_invalid_reference_price_raises():
         evaluator.compute_metrics(0.0, _forward([1.0]), direction=1)
 
 
-def test_contiguous_forward_stops_at_gap():
+def test_contiguous_forward_counts_actual_candles_skipping_closures():
+    # Bar counting: a missing bar (weekend/holiday/closure) is not a gap that
+    # blocks; the Nth forward bar is the Nth actual candle. Dropping one candle
+    # from ten leaves nine forward bars, in time order.
     closes = [1.0 + i for i in range(10)]
     forward = _forward(closes)
     candle_map = {timeutil.parse_ts(b["open_time"]): b for b in forward}
-    # drop bar 6 -> only 5 contiguous
-    del candle_map[timeutil.parse_ts(forward[5]["open_time"])]
+    dropped = forward[5]
+    del candle_map[timeutil.parse_ts(dropped["open_time"])]
     got, verified = evaluator.contiguous_forward(candle_map, REF_CLOSE_TIME, want=10)
-    assert verified == 5
+    assert verified == 9
+    assert dropped not in got  # the closed/absent bar simply does not appear
+    times = [timeutil.parse_ts(b["open_time"]) for b in got]
+    assert times == sorted(times)  # still in chronological order

--- a/scripts/vps/csm_status.py
+++ b/scripts/vps/csm_status.py
@@ -1,0 +1,92 @@
+# coding: utf-8
+r"""
+CSM review pipeline status — read-only, run any day to see health at a glance.
+
+    python scripts\vps\csm_status.py
+
+Prints: review snapshot counts (valid/invalid), cases by status, candle coverage,
+the latest job run per stage with age, and the public review count. Touches no
+data. Resolves the repo root itself so it runs from anywhere.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from intellitrade_scanners import config  # noqa: E402
+
+config.load_env()
+
+from intellitrade_scanners.postgrest import Postgrest  # noqa: E402
+
+UTC = dt.timezone.utc
+
+
+def _parse(ts):
+    if not ts:
+        return None
+    try:
+        return dt.datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _age(ts) -> str:
+    d = _parse(ts)
+    if not d:
+        return "n/a"
+    mins = (dt.datetime.now(UTC) - d).total_seconds() / 60
+    return f"{mins/60:.1f}h ago" if mins >= 60 else f"{mins:.0f}m ago"
+
+
+def main() -> int:
+    db = Postgrest()
+    print("=" * 56)
+    print("CSM REVIEW PIPELINE STATUS", dt.datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC"))
+    print("=" * 56)
+
+    snaps = db.select("csm_review_snapshots", columns="completeness")
+    valid = sum(1 for s in snaps if s["completeness"] == "complete")
+    print(f"\nReview snapshots : {len(snaps)} total  ({valid} valid, {len(snaps)-valid} invalid)")
+
+    cases = db.select("csm_review_cases", columns="status")
+    print(f"Cases            : {len(cases)} total")
+    counts: dict[str, int] = {}
+    for c in cases:
+        counts[c["status"]] = counts.get(c["status"], 0) + 1
+    for status, n in sorted(counts.items()):
+        print(f"    {status:26} {n}")
+
+    candles = db.select("fx_ohlc_candles", columns="symbol,open_time")
+    symbols = {c["symbol"] for c in candles}
+    latest = max((c["open_time"] for c in candles), default=None)
+    print(f"\nCandles          : {len(candles)} rows, {len(symbols)}/28 pairs")
+    print(f"    newest bar open : {latest} ({_age(latest)})")
+
+    public = db.select("csm_public_reviews", columns="slug")
+    print(f"\nPublished reviews: {len(public)}")
+
+    runs = db.select("csm_review_job_runs", columns="job_name,status,finished_at")
+    latest_by_stage: dict[str, dict] = {}
+    for r in runs:
+        prev = latest_by_stage.get(r["job_name"])
+        if prev is None or str(r.get("finished_at")) > str(prev.get("finished_at")):
+            latest_by_stage[r["job_name"]] = r
+    print("\nLast run per stage:")
+    for stage in ("ingest", "candles", "detect", "evaluate", "publish", "aggregate"):
+        r = latest_by_stage.get(stage)
+        if r:
+            print(f"    {stage:10} {r['status']:8} {_age(r.get('finished_at'))}")
+        else:
+            print(f"    {stage:10} (never run)")
+
+    print("\n" + "=" * 56)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
…luation

The forward-bar walk stopped at the first missing weekday grid slot, so any case whose 60-bar window crossed a market holiday (Dec 25, Jan 1, Good Friday, etc.) would stall and be withheld. Per the horizon convention, closures vanish through bar counting exactly like weekends: forward bar N is now the Nth ACTUAL closed candle after the reference, in time order. Genuine multi-day feed outages still surface via the candles-stage gap detection + watchdog.