### PR TITLE
fix: paginate PostgREST selects past the 1000-row cap

### DIFF
--- a/intellitrade_scanners/postgrest.py
+++ b/intellitrade_scanners/postgrest.py
@@ -77,11 +77,15 @@ class Postgrest:
     def _request(self, method: str, table: str,
                  params: list[tuple[str, str]],
                  json_body: object = None,
-                 prefer: str = "return=representation") -> list[dict]:
+                 prefer: str = "return=representation",
+                 extra_headers: Mapping | None = None) -> list[dict]:
+        headers = {"Prefer": prefer}
+        if extra_headers:
+            headers.update(extra_headers)
         resp = self._session.request(
             method, f"{self._rest}/{table}",
             params=params, json=json_body,
-            headers={"Prefer": prefer},
+            headers=headers,
             timeout=self._timeout,
         )
         if not (200 <= resp.status_code < 300):
@@ -95,9 +99,30 @@ class Postgrest:
     def _rows(rows: Mapping | list) -> list:
         return [dict(rows)] if isinstance(rows, Mapping) else list(rows)
 
+    _PAGE = 1000
+
     def select(self, table: str, columns: str = "*",
                filters: Iterable[Filter] = ()) -> list[dict]:
-        return self._request("GET", table, [("select", columns), *filters])
+        """Fetch all matching rows, paginating past PostgREST's default row cap.
+
+        PostgREST returns at most ~1000 rows per response (and in no guaranteed
+        order). Paginate with the Range header so callers always get the complete
+        set. Filters/params are unchanged, so the request shape callers see is
+        identical to a single-page fetch."""
+        params = [("select", columns), *filters]
+        rows: list[dict] = []
+        start = 0
+        while True:
+            batch = self._request(
+                "GET", table, params,
+                extra_headers={"Range-Unit": "items",
+                               "Range": f"{start}-{start + self._PAGE - 1}"},
+            )
+            rows.extend(batch)
+            if len(batch) < self._PAGE:
+                break
+            start += self._PAGE
+        return rows
 
     def insert(self, table: str, rows: Mapping | list) -> list[dict]:
         return self._request("POST", table, [], self._rows(rows))

--- a/intellitrade_scanners/tests/test_postgrest.py
+++ b/intellitrade_scanners/tests/test_postgrest.py
@@ -111,6 +111,43 @@ def test_delete_with_range_and_not_in(client):
     assert ("scraperID", 'not.in.("a","b")') in call["params"]
 
 
+class PagingSession:
+    """Returns full pages until a short one, so select() must paginate."""
+
+    def __init__(self, page_sizes):
+        self.headers = {}
+        self.page_sizes = list(page_sizes)
+        self.calls = []
+
+    def request(self, method, url, params=None, json=None, headers=None, timeout=None):
+        self.calls.append({"params": params, "headers": headers})
+        n = self.page_sizes[len(self.calls) - 1]
+        return FakeResponse(payload=[{"i": i} for i in range(n)])
+
+
+def test_select_paginates_past_the_1000_row_cap(client):
+    db, _ = client()
+    paging = PagingSession([1000, 1000, 500])  # 2500 rows across 3 pages
+    db._session = paging
+    rows = db.select("fx_ohlc_candles", "open_time", [eq("symbol", "EURJPY")])
+    assert len(rows) == 2500
+    assert len(paging.calls) == 3
+    # Range header advances each page; filter params are unchanged.
+    assert paging.calls[0]["headers"]["Range"] == "0-999"
+    assert paging.calls[1]["headers"]["Range"] == "1000-1999"
+    assert paging.calls[2]["headers"]["Range"] == "2000-2999"
+    assert paging.calls[0]["params"] == [("select", "open_time"), ("symbol", "eq.EURJPY")]
+
+
+def test_select_single_page_stops_after_one_call(client):
+    db, _ = client()
+    paging = PagingSession([10])  # short first page -> no second call
+    db._session = paging
+    rows = db.select("scanner_health")
+    assert len(rows) == 10
+    assert len(paging.calls) == 1
+
+
 def test_quote_escapes_embedded_quotes():
     assert postgrest._quote('va"l') == '"va\\"l"'
 


### PR DESCRIPTION
PostgREST returns at most ~1000 rows per response, unordered. Postgrest.select() took only the first page, so as review data grows the detector (which selects all valid snapshots to run the state engine) and the candle/status reads would silently truncate and mis-detect. select() now pages with the Range header until a short page; request params are unchanged so existing call shapes hold. Affects every caller of the shared client, all read-completeness improvements only.